### PR TITLE
refactor: Replace `@enumx` with`@anonymousenum` macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["singularitti <singularitti@outlook.com>"]
 version = "0.10.0"
 
 [deps]
+AnonymousEnums = "1b8a1bdb-a29a-4350-a16c-c7e9322d6a39"
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.10.0"
 
 [deps]
 AnonymousEnums = "1b8a1bdb-a29a-4350-a16c-c7e9322d6a39"
-EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Mendeleev = "c116f080-063d-490a-9873-2b5b2cce4c34"
@@ -13,7 +12,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructEquality = "6ec83bb0-ed9f-11e9-3b4c-2b04cb4e219c"
 
 [compat]
-EnumX = "1"
 Functors = "0.1, 0.2, 0.3, 0.4"
 Mendeleev = "0.2, 0.3, 1"
 StaticArrays = "0.8.3, 0.9, 0.10, 0.11, 0.12, 1"

--- a/docs/src/public.md
+++ b/docs/src/public.md
@@ -12,9 +12,6 @@ Depth = 3
 ## Lattice and Cell
 
 ```@docs
-CrystalSystem
-LatticeSystem
-Bravais
 AbstractLattice
 Lattice
 isrighthanded

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -91,22 +91,22 @@ basisvectors(lattice::Lattice) = lattice[:, 1], lattice[:, 2], lattice[:, 3]
 
 Get the lattice system of a Bravais lattice.
 """
-function latticesystem(bravais::Bravais.T)
+function latticesystem(bravais::Bravais)
     index = Int(bravais)
     if index == 1
-        return LatticeSystem.Triclinic
+        return LatticeSystem(:Triclinic)
     elseif 2 <= index <= 3
-        return LatticeSystem.Monoclinic
+        return LatticeSystem(:Monoclinic)
     elseif 4 <= index <= 7
-        return LatticeSystem.Orthorhombic
+        return LatticeSystem(:Orthorhombic)
     elseif 8 <= index <= 9
-        return LatticeSystem.Tetragonal
+        return LatticeSystem(:Tetragonal)
     elseif index == 10
-        return LatticeSystem.Hexagonal
+        return LatticeSystem(:Hexagonal)
     elseif index == 11
-        return LatticeSystem.Rhombohedral
+        return LatticeSystem(:Rhombohedral)
     else  # 12 <= index <= 14
-        return LatticeSystem.Cubic
+        return LatticeSystem(:Cubic)
     end
 end
 """
@@ -141,25 +141,25 @@ function latticesystem(a, b, c, α, β, γ; angletol=1e-5, lengthtol=1e-5)
     for (lengths′, angles′) in zip(cyclic_perm(lengths), cyclic_perm(angles))
         (a′, _, c′), (α′, β′, γ′) = lengths′, angles′
         if !(a′ ≅ c′) && α′ ≊ 90 && γ′ ≊ 90 && !(β′ ≊ 90)
-            return LatticeSystem.Monoclinic
+            return LatticeSystem(:Monoclinic)
         end
     end
     if unilength && uniangle
-        return α ≊ 90 ? LatticeSystem.Cubic : LatticeSystem.Rhombohedral
+        return α ≊ 90 ? LatticeSystem(:Cubic) : LatticeSystem(:Rhombohedral)
     end
     if unilength && !uniangle  # Technically, a hexagonal system could have all 3 lengths equal.
         if any(θ ≊ 120 for θ in angles) && sum(θ ≊ 90 for θ in angles) == 2
-            return LatticeSystem.Hexagonal
+            return LatticeSystem(:Hexagonal)
         end
     end
     if bilengths(lengths)  # At this point, two lengths are equal at most.
         if uniangle && α ≊ 90
-            return LatticeSystem.Tetragonal
+            return LatticeSystem(:Tetragonal)
         elseif any(θ ≊ 120 for θ in angles) && sum(θ ≊ 90 for θ in angles) == 2
-            return LatticeSystem.Hexagonal
+            return LatticeSystem(:Hexagonal)
         end
     else  # At this point, all lengths are not equal.
-        return uniangle && α ≊ 90 ? LatticeSystem.Orthorhombic : LatticeSystem.Triclinic
+        return uniangle && α ≊ 90 ? LatticeSystem(:Orthorhombic) : LatticeSystem(:Triclinic)
     end
 end
 """

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -1,9 +1,9 @@
-using EnumX: @enumx
+using AnonymousEnums: @anonymousenum
 
 export CrystalSystem, LatticeSystem, Bravais
 
 "Represent the 7 lattice systems."
-@enumx LatticeSystem begin
+@anonymousenum LatticeSystem begin
     Triclinic = 1
     Monoclinic = 2
     Orthorhombic = 3
@@ -14,7 +14,7 @@ export CrystalSystem, LatticeSystem, Bravais
 end
 
 "Represent the 7 crystal systems."
-@enumx CrystalSystem begin
+@anonymousenum CrystalSystem begin
     Triclinic = 1
     Monoclinic = 2
     Orthorhombic = 3
@@ -25,7 +25,7 @@ end
 end
 
 "Represent the 14 Bravais lattices."
-@enumx BravaisArithmeticClass begin
+@anonymousenum BravaisArithmeticClass begin
     PrimitiveTriclinic = 1
     PrimitiveMonoclinic = 2
     BaseCenteredMonoclinic = 3

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -37,7 +37,6 @@ end
     BodyCenteredTetragonal = 9
     PrimitiveHexagonal = 10
     PrimitiveRhombohedral = 11
-    RCentredHexagonal = PrimitiveRhombohedral
     PrimitiveCubic = 12
     BodyCenteredCubic = 13
     FaceCenteredCubic = 14

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -2,7 +2,6 @@ using AnonymousEnums: @anonymousenum
 
 export CrystalSystem, LatticeSystem, Bravais
 
-"Represent the 7 lattice systems."
 @anonymousenum LatticeSystem begin
     Triclinic = 1
     Monoclinic = 2
@@ -13,7 +12,6 @@ export CrystalSystem, LatticeSystem, Bravais
     Cubic = 7
 end
 
-"Represent the 7 crystal systems."
 @anonymousenum CrystalSystem begin
     Triclinic = 1
     Monoclinic = 2
@@ -24,7 +22,6 @@ end
     Cubic = 7
 end
 
-"Represent the 14 Bravais lattices."
 @anonymousenum BravaisArithmeticClass begin
     PrimitiveTriclinic = 1
     PrimitiveMonoclinic = 2

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -1,6 +1,6 @@
 using AnonymousEnums: @anonymousenum
 
-export CrystalSystem, LatticeSystem, Bravais
+export CrystalSystem, LatticeSystem, BravaisArithmeticClass, Bravais
 
 @anonymousenum LatticeSystem begin
     Triclinic = 1

--- a/test/lattice.jl
+++ b/test/lattice.jl
@@ -10,7 +10,7 @@
             0u"bohr" 0u"nm" (3//1)*u"angstrom"
         ]
     )
-    @test latticesystem(lattice; lengthtol=1e-5u"bohr") == LatticeSystem.Orthorhombic
+    @test latticesystem(lattice; lengthtol=1e-5u"bohr") == LatticeSystem(:Orthorhombic)
 end
 
 @testset "Test creating `Lattice`s from 6 lattice constants" begin
@@ -92,16 +92,16 @@ end
 
 # See https://github.com/LaurentRDC/crystals/blob/7c544fe/crystals/tests/test_lattice.py#L156-L209
 @testset "Test `latticesystem` from 6 lattice constants" begin
-    @test latticesystem(2, 2, 3, 90, 90, 90) == LatticeSystem.Tetragonal
-    @test latticesystem(1, 1, 1, 87, 87, 87) == LatticeSystem.Rhombohedral
-    @test latticesystem(1, 2, 3, 90, 115, 90) == LatticeSystem.Monoclinic
-    @test latticesystem(2, 3, 1, 115, 90, 90) == LatticeSystem.Monoclinic
-    @test latticesystem(3, 1, 2, 90, 90, 115) == LatticeSystem.Monoclinic
-    @test latticesystem(2, 2, 3, 90, 90, 120) == LatticeSystem.Hexagonal
-    @test latticesystem(3, 2, 2, 120, 90, 90) == LatticeSystem.Hexagonal
-    @test latticesystem(2, 3, 2, 90, 120, 90) == LatticeSystem.Hexagonal
-    @test latticesystem(2, 2, 2, 90, 120, 90) == LatticeSystem.Hexagonal
-    @test latticesystem(1, 2, 3, 75, 40, 81) == LatticeSystem.Triclinic
+    @test latticesystem(2, 2, 3, 90, 90, 90) == LatticeSystem(:Tetragonal)
+    @test latticesystem(1, 1, 1, 87, 87, 87) == LatticeSystem(:Rhombohedral)
+    @test latticesystem(1, 2, 3, 90, 115, 90) == LatticeSystem(:Monoclinic)
+    @test latticesystem(2, 3, 1, 115, 90, 90) == LatticeSystem(:Monoclinic)
+    @test latticesystem(3, 1, 2, 90, 90, 115) == LatticeSystem(:Monoclinic)
+    @test latticesystem(2, 2, 3, 90, 90, 120) == LatticeSystem(:Hexagonal)
+    @test latticesystem(3, 2, 2, 120, 90, 90) == LatticeSystem(:Hexagonal)
+    @test latticesystem(2, 3, 2, 90, 120, 90) == LatticeSystem(:Hexagonal)
+    @test latticesystem(2, 2, 2, 90, 120, 90) == LatticeSystem(:Hexagonal)
+    @test latticesystem(1, 2, 3, 75, 40, 81) == LatticeSystem(:Triclinic)
 end
 
 @testset "Test `periodicity`" begin


### PR DESCRIPTION
Using `AnonymousEnums.jl` can lead to better looking syntax.