### PR TITLE
Rename `FractionalFromCartesian` to `ReducedFromCartesian`, etc.

### DIFF
--- a/src/transform.jl
+++ b/src/transform.jl
@@ -17,8 +17,8 @@ end
 # This requires the a-vector is parallel to the Cartesian x-axis.
 # See https://en.wikipedia.org/wiki/Fractional_coordinates
 """
-    CartesianFromFractional(lattice::Union{Lattice,ReciprocalLattice})
-    CartesianFromFractional(a, b, c, α, β, γ)
+    CartesianFromReduced(lattice::Union{Lattice,ReciprocalLattice})
+    CartesianFromReduced(a, b, c, α, β, γ)
 
 Get the transformation from fractional coordinates to Cartesian coordinates.
 """
@@ -37,8 +37,8 @@ function CartesianFromReduced(a, b, c, α, β, γ)
     )
 end
 """
-    FractionalFromCartesian(lattice::Union{Lattice,ReciprocalLattice})
-    FractionalFromCartesian(a, b, c, α, β, γ)
+    ReducedFromCartesian(lattice::Union{Lattice,ReciprocalLattice})
+    ReducedFromCartesian(a, b, c, α, β, γ)
 
 Get the transformation from Cartesian coordinates to fractional coordinates.
 """

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -1,17 +1,17 @@
-export FractionalFromCartesian,
-    CartesianFromFractional,
-    FractionalToCartesian,
-    CartesianToFractional,
+export ReducedFromCartesian,
+    CartesianFromReduced,
+    ReducedToCartesian,
+    CartesianToReduced,
     StandardizedFromPrimitive,
     PrimitiveFromStandardized,
     PrimitiveToStandardized,
     StandardizedToPrimitive
 
 abstract type ChangeOfBasis{T} <: AbstractMatrix{T} end
-struct CartesianFromFractional{T} <: ChangeOfBasis{T}
+struct CartesianFromReduced{T} <: ChangeOfBasis{T}
     tf::MMatrix{3,3,T,9}
 end
-struct FractionalFromCartesian{T} <: ChangeOfBasis{T}
+struct ReducedFromCartesian{T} <: ChangeOfBasis{T}
     tf::MMatrix{3,3,T,9}
 end
 # This requires the a-vector is parallel to the Cartesian x-axis.
@@ -22,13 +22,13 @@ end
 
 Get the transformation from fractional coordinates to Cartesian coordinates.
 """
-CartesianFromFractional(lattice::Lattice) = CartesianFromFractional(parent(lattice))
-CartesianFromFractional(lattice::ReciprocalLattice) =
-    CartesianFromFractional(transpose(parent(lattice)))
-function CartesianFromFractional(a, b, c, α, β, γ)
+CartesianFromReduced(lattice::Lattice) = CartesianFromReduced(parent(lattice))
+CartesianFromReduced(lattice::ReciprocalLattice) =
+    CartesianFromReduced(transpose(parent(lattice)))
+function CartesianFromReduced(a, b, c, α, β, γ)
     Ω = cellvolume(a, b, c, α, β, γ)
     b_sinγ, b_cosγ = b .* (sind(γ), cosd(γ))
-    return CartesianFromFractional(
+    return CartesianFromReduced(
         [
             a b_cosγ c*cosd(β)
             0 b_sinγ c*_auxiliary(α, β, γ)
@@ -42,13 +42,13 @@ end
 
 Get the transformation from Cartesian coordinates to fractional coordinates.
 """
-FractionalFromCartesian(lattice::Lattice) = FractionalFromCartesian(inv(parent(lattice)))
-FractionalFromCartesian(lattice::ReciprocalLattice) =
-    FractionalFromCartesian(transpose(inv(parent(lattice))))
-function FractionalFromCartesian(a, b, c, α, β, γ)
+ReducedFromCartesian(lattice::Lattice) = ReducedFromCartesian(inv(parent(lattice)))
+ReducedFromCartesian(lattice::ReciprocalLattice) =
+    ReducedFromCartesian(transpose(inv(parent(lattice))))
+function ReducedFromCartesian(a, b, c, α, β, γ)
     Ω = cellvolume(a, b, c, α, β, γ)
     b_sinγ = b * sind(γ)
-    return FractionalFromCartesian(
+    return ReducedFromCartesian(
         [
             1/a -cotd(γ)/a -b * c * _auxiliary(β, α, γ)/Ω
             0 1/b_sinγ -a * c * _auxiliary(α, β, γ)/Ω
@@ -56,20 +56,20 @@ function FractionalFromCartesian(a, b, c, α, β, γ)
         ],
     )
 end
-const FractionalToCartesian = CartesianFromFractional
-const CartesianToFractional = FractionalFromCartesian
+const ReducedToCartesian = CartesianFromReduced
+const CartesianToReduced = ReducedFromCartesian
 
 # This is a helper function and should not be exported!
 _auxiliary(α, β, γ) = (cosd(α) - cosd(β) * cosd(γ)) / sind(γ)
 
-(x::Union{CartesianFromFractional,FractionalFromCartesian})(v) = x.tf * collect(v)
-(x::Union{CartesianFromFractional,FractionalFromCartesian})(p::ReciprocalPoint) =
+(x::Union{CartesianFromReduced,ReducedFromCartesian})(v) = x.tf * collect(v)
+(x::Union{CartesianFromReduced,ReducedFromCartesian})(p::ReciprocalPoint) =
     ReciprocalPoint(x.tf * collect(p.coord), p.weight)
 
-Base.inv(x::FractionalFromCartesian) = CartesianFromFractional(inv(x.tf))
-Base.inv(x::CartesianFromFractional) = FractionalFromCartesian(inv(x.tf))
-Base.:∘(x::CartesianFromFractional, y::FractionalFromCartesian) = ∘(y, x)
-Base.:∘(x::FractionalFromCartesian, y::CartesianFromFractional) =
+Base.inv(x::ReducedFromCartesian) = CartesianFromReduced(inv(x.tf))
+Base.inv(x::CartesianFromReduced) = ReducedFromCartesian(inv(x.tf))
+Base.:∘(x::CartesianFromReduced, y::ReducedFromCartesian) = ∘(y, x)
+Base.:∘(x::ReducedFromCartesian, y::CartesianFromReduced) =
     x.tf * y.tf ≈ I ? identity : error("undefined!")
 
 # Idea from https://spglib.github.io/spglib/definition.html#transformation-to-the-primitive-cell

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -4,12 +4,12 @@
         0 1/2 0
         0 0 1
     ])
-    @test CartesianFromFractional(lattice)([2, 3, 1]) == [1, 3 / 2, 1]
+    @test CartesianFromReduced(lattice)([2, 3, 1]) == [1, 3 / 2, 1]
     # Compared with "SeeK-path" example oC1 (SiTi)
     @testset "Base centered orthorhombic" begin
         a, b, c = 3.67939899, 4.15357986, 3.8236792350
         lattice = Lattice([a, -b, 0] / 2, [a, b, 0] / 2, [0, 0, c])
-        f2c = CartesianFromFractional(lattice)
+        f2c = CartesianFromReduced(lattice)
         @test f2c([1 / 2, 1 / 2, 1 / 2]) == [1.8396994950, 0, 1.9118396175]  # Si
         @test f2c([0, 0, 0]) == [0, 0, 0]  # Ti
         c2f = inv(f2c)
@@ -54,13 +54,13 @@ end
     @testset "Simple orthorhombic Brillouin zone" begin
         a, b, c = 2, 3, 5
         reci_lattice = reciprocal(Lattice(a, b, c, 90, 90, 90))
-        f2c = CartesianFromFractional(reci_lattice)
+        f2c = CartesianFromReduced(reci_lattice)
         @test f2c([1 / 2, 0, 0]) == [1 / a, 0, 0] / 2
         @test f2c([0, 1 / 2, 0]) == [0, 1 / b, 0] / 2
         @test f2c([0, 0, 1 / 2]) == [0, 0, 1 / c] / 2
         @test f2c([0, 1 / 2, 1 / 2]) == [0, 1 / b, 1 / c] / 2
         @test f2c([1 / 2, 1 / 2, 0]) == [1 / a, 1 / b, 0] / 2
-        c2f = FractionalFromCartesian(reci_lattice)
+        c2f = ReducedFromCartesian(reci_lattice)
         @test c2f([1 / a, 0, 0] / 2) == [1 / 2, 0, 0]
         @test c2f([0, 1 / b, 0] / 2) == [0, 1 / 2, 0]
         @test c2f([0, 0, 1 / c] / 2) == [0, 0, 1 / 2]
@@ -73,7 +73,7 @@ end
     @testset "Base centered orthorhombic Brillouin zone" begin
         a, b, c = 3.67939899, 4.15357986, 3.8236792350
         reci_lattice = reciprocal(Lattice([a, -b, 0] / 2, [a, b, 0] / 2, [0, 0, c]))
-        f2c = CartesianFromFractional(reci_lattice)
+        f2c = CartesianFromReduced(reci_lattice)
         @test f2c([-1 / 2, 1 / 2, 0]) ≈ [0, 1 / b, 0] ≈ [0, 1.5127156619, 0] / 2pi  # Y'
         @test f2c([0, 0, 1 / 2]) ≈ [0, 0, 1 / 2 / c] ≈ [0, 0, 0.8216151148] / 2pi  # Z
         @test f2c([-1 / 2, 1 / 2, 1 / 2]) ≈
@@ -87,7 +87,7 @@ end
             [0.8538331021, 0.7563578310, 0.8216151148] / 2pi # R
         @test f2c([-0.4461772527, 0.5538227473, 1 / 2]) ≈
             [0.1838225731, 1.5127156619, 0.8216151148] / 2pi  # E0
-        c2f = FractionalFromCartesian(reci_lattice)
+        c2f = ReducedFromCartesian(reci_lattice)
         @test c2f([0, 1 / b, 0]) ≈ [-1 / 2, 1 / 2, 0]
         @test c2f([0, 0, 1 / 2 / c]) ≈ [0, 0, 1 / 2]
         @test c2f([0, 1 / b, 1 / 2 / c]) ≈ [-1 / 2, 1 / 2, 1 / 2]
@@ -101,13 +101,13 @@ end
     @testset "Body centered tetragonal Brillouin zone" begin
         a, c = 4, 6
         reci_lattice = reciprocal(Lattice([a, a, -c] / 2, [a, -a, c] / 2, [-a, a, c] / 2))
-        f2c = CartesianFromFractional(reci_lattice)
+        f2c = CartesianFromReduced(reci_lattice)
         @test f2c([0, 0, 0]) == [0, 0, 0]
         @test f2c([1 / 2, 0, 0]) == [1 / a, 1 / a, 0] / 2
         @test f2c([1 / 2, 1 / 2, -1 / 2]) == [1 / a, 0, 0]
         @test f2c([0, 1 / 2, 0]) == [1 / a, 0, 1 / c] / 2
         @test f2c([1, 1, 1] / 4) == [1 / a, 1 / a, 1 / c] / 2
-        c2f = FractionalFromCartesian(reci_lattice)
+        c2f = ReducedFromCartesian(reci_lattice)
         @test c2f([0, 0, 0]) == [0, 0, 0]
         @test c2f([1 / a, 1 / a, 0] / 2) == [1 / 2, 0, 0]
         @test c2f([1 / a, 0, 0]) == [1 / 2, 1 / 2, -1 / 2]
@@ -121,14 +121,14 @@ end
         reci_lattice = reciprocal(
             Lattice([a, 0, 0], [a / 2, sqrt(3) / 2 * a, 0], [0, 0, c])
         )
-        f2c = CartesianFromFractional(reci_lattice)
+        f2c = CartesianFromReduced(reci_lattice)
         @test f2c([0, 0, 0]) == [0, 0, 0]  # Γ
         @test f2c([1 / 2, 0, 0]) ≈ [1 / a, -1 / sqrt(3) / a, 0] / 2  # M
         @test f2c([0, 0, 1 / 2]) ≈ [0, 0, 1 / c] / 2  # A
         @test f2c([2 / 3, 1 / 3, 0]) ≈ [2 / 3 / a, 0, 0]  # K
         @test f2c([2 / 3, 1 / 3, 1 / 2]) ≈ [2 / 3 / a, 0, 1 / 2 / c]  # H
         @test f2c([1 / 2, 0, 1 / 2]) ≈ [1 / a, -1 / sqrt(3) / a, 1 / c] / 2  # L
-        c2f = FractionalFromCartesian(reci_lattice)
+        c2f = ReducedFromCartesian(reci_lattice)
         @test c2f([0, 0, 0]) == [0, 0, 0]
         @test c2f([1 / a, -1 / sqrt(3) / a, 0] / 2) ≈ [1 / 2, 0, 0]
         @test c2f([0, 0, 1 / c] / 2) == [0, 0, 1 / 2]
@@ -141,11 +141,11 @@ end
     @testset "Simple cubic Brillouin zone" begin
         a = 4
         reci_lattice = reciprocal(Lattice(a, a, a, 90, 90, 90))
-        f2c = CartesianFromFractional(reci_lattice)
+        f2c = CartesianFromReduced(reci_lattice)
         @test f2c([0, 0, 0]) == [0, 0, 0]
         @test f2c([1 / 2, 1 / 2, 0]) == [1 / a, 1 / a, 0] / 2
         @test f2c([1 / 2, 1 / 2, 1 / 2]) == [1 / a, 1 / a, 1 / a] / 2
-        c2f = FractionalFromCartesian(reci_lattice)
+        c2f = ReducedFromCartesian(reci_lattice)
         @test c2f([0, 0, 0]) == [0, 0, 0]
         @test c2f([1 / a, 1 / a, 0] / 2) == [1 / 2, 1 / 2, 0]
         @test c2f([1 / a, 1 / a, 1 / a] / 2) == [1 / 2, 1 / 2, 1 / 2]
@@ -159,14 +159,14 @@ end
             0 1 1
             1 0 1
         ]) * a / 2)
-        f2c = CartesianFromFractional(reci_lattice)
+        f2c = CartesianFromReduced(reci_lattice)
         @test f2c([0, 0, 0]) == [0, 0, 0]
         @test f2c([0, 1 / 2, 1 / 2]) == [0, 1 / a, 0]
         @test f2c([1 / 2, 1 / 2, 1 / 2]) == [1 / a, 1 / a, 1 / a] / 2
         @test f2c([1 / 4, 3 / 4, 1 / 2]) == [1 / 2 / a, 1 / a, 0]
         @test f2c([1 / 4, 5 / 8, 5 / 8]) == [1 / 2 / a, 2 / a, 1 / 2 / a] / 2
         @test f2c([3 / 8, 3 / 4, 3 / 8]) == [3 / 2 / a, 3 / 2 / a, 0] / 2
-        c2f = FractionalFromCartesian(reci_lattice)
+        c2f = ReducedFromCartesian(reci_lattice)
         @test c2f([0, 0, 0]) == [0, 0, 0]
         @test f2c([0, 1 / 2, 1 / 2]) == [0, 1 / a, 0]
         @test f2c([1 / 2, 1 / 2, 1 / 2]) == [1 / a, 1 / a, 1 / a] / 2
@@ -183,12 +183,12 @@ end
             1 1 -1
             -1 1 1
         ]) * a / 2)
-        f2c = CartesianFromFractional(reci_lattice)
+        f2c = CartesianFromReduced(reci_lattice)
         @test f2c([0, 0, 0]) == [0, 0, 0]
         @test f2c([-1 / 2, 1 / 2, 1 / 2]) == [0, 0, 1 / a]
         @test f2c([1 / 4, 1 / 4, 1 / 4]) == [1 / a, 1 / a, 1 / a] / 2
         @test f2c([0, 1 / 2, 0]) == [0, 1 / a, 1 / a] / 2
-        c2f = FractionalFromCartesian(reci_lattice)
+        c2f = ReducedFromCartesian(reci_lattice)
         @test c2f([0, 0, 0]) == [0, 0, 0]
         @test c2f([0, 0, 1 / a]) == [-1 / 2, 1 / 2, 1 / 2]
         @test c2f([1 / a, 1 / a, 1 / a] / 2) == [1 / 4, 1 / 4, 1 / 4]
@@ -1135,6 +1135,6 @@ end
             -0.0132935 -0.0 -0.014049
             0.0 0.0 0.0
         ]' * u"bohr^-1"
-    f2c = CartesianFromFractional(reci_lattice)
+    f2c = CartesianFromReduced(reci_lattice)
     @test maximum(abs.(f2c(qe_crystal) - qe_cartesian)) < 1e-5u"bohr^-1"
 end


### PR DESCRIPTION
They don't have to be fractional, they are just reduced atomic/wave-vector coordinates