### PR TITLE
Deprecate `MetricTensor` applied on vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ PeriodicTableExt = "PeriodicTable"
 
 [compat]
 AnonymousEnums = "0.1"
-CrystallographyCore = "0.1, 0.2, 0.3, 0.4"
+CrystallographyCore = "0.4.2"
 Mendeleev = "0.2, 0.3, 1"
 Reexport = "1"
 StaticArrays = "0.8.3, 0.9, 0.10, 0.11, 0.12, 1"

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -44,6 +44,7 @@ reciprocal
 
 ```@docs
 MetricTensor
+lengthof
 distance
 ```
 

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -34,8 +34,6 @@ function MetricTensor(a, b, c, α, β, γ)
     return MetricTensor(SHermitianCompact(SVector(a^2, g₁₂, g₁₃, b^2, g₂₃, c^2)))
 end
 
-(g::MetricTensor)(𝐚::AbstractVector) = sqrt(dot(𝐚, g, 𝐚))
-(g::MetricTensor)(𝐚::AbstractVector, 𝐛::AbstractVector) = g(𝐚 - 𝐛)
 
 """
     distance(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector)

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -42,11 +42,11 @@ Get the length of coordinates `𝐚`.
 lengthof(𝐚::ReducedCoordinates, g::MetricTensor) = sqrt(dot(𝐚, g, 𝐚))
 
 """
-    distance(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector)
+    distance(𝐚::ReducedCoordinates, g::MetricTensor, 𝐛::ReducedCoordinates)
 
 Get the distance between two coordinates using a `MetricTensor`.
 """
-distance(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector) = g(𝐚, 𝐛)
+distance(𝐚::ReducedCoordinates, g::MetricTensor, 𝐛::ReducedCoordinates) = lengthof(𝐚 - 𝐛, g)
 
 """
     Lattice(g::MetricTensor)

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -1,6 +1,6 @@
 using StaticArrays: SHermitianCompact, SDiagonal
 
-export MetricTensor, distance
+export MetricTensor, lengthof, distance
 
 struct MetricTensor{T} <: AbstractMatrix{T}
     data::SHermitianCompact{3,T,6}
@@ -34,6 +34,12 @@ function MetricTensor(a, b, c, α, β, γ)
     return MetricTensor(SHermitianCompact(SVector(a^2, g₁₂, g₁₃, b^2, g₂₃, c^2)))
 end
 
+"""
+    lengthof(𝐚::ReducedCoordinates, g::MetricTensor)
+
+Get the length of coordinates `𝐚`.
+"""
+lengthof(𝐚::ReducedCoordinates, g::MetricTensor) = sqrt(dot(𝐚, g, 𝐚))
 
 """
     distance(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector)

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -27,15 +27,14 @@ end
         0.0 sqrt(3)/2 0.0
         0.0 0.0 2.0
     ]))
-    a = [1, 2, 1]
-    @test dot(a, g, a) ≈ 7
-    @test g([1, 2, 1])^2 ≈ 7
+    𝐚 = ReducedCoordinates(1, 2, 1)
+    @test lengthof(𝐚, g)^2 ≈ 7
 end
 
 @testset "Test distance between atoms in a hexagonal lattice" begin
     g = MetricTensor(1, 1, 2, 90, 90, 120)  # Primitive hexagonal
-    a = [1, 1, 1]
-    b = [1//3, 1//3, 1//2]
+    a = ReducedCoordinates(1, 1, 1)
+    b = ReducedCoordinates(1//3, 1//3, 1//2)
     @test distance(a, g, b)^2 == 13 / 9
 end
 


### PR DESCRIPTION
See https://github.com/MineralsCloud/CrystallographyCore.jl/pull/22